### PR TITLE
Fix typo in closing "if" block

### DIFF
--- a/c9cli.sh
+++ b/c9cli.sh
@@ -1212,7 +1212,7 @@ updates() {
     echo "Error: Received HTML response instead of script file"
     echo "Please check if the update server URL is correct"
     return 1
-  }
+  fi
 
   latest_version=""
   if echo "$latest_info" | grep -q 'VERSION='; then


### PR DESCRIPTION
Typo in closing "if" block leads to syntax error 
```/usr/local/bin/c9cli: line 1215: syntax error near unexpected token `}'```